### PR TITLE
fix averaged-perceptron alias

### DIFF
--- a/src/crfsuite.pyx
+++ b/src/crfsuite.pyx
@@ -64,7 +64,7 @@ FITTYPE_DICT = {'1d': 'crf1d'}
 ALGORITHM_DICT = {'lbfgs': 'lbfgs',
                   'l2sgd': 'l2sgd',
                   'ap': 'averaged-perceptron',
-                  'averaged-perceptron': 'averaged_perceptron',
+                  'averaged-perceptron': 'averaged-perceptron',
                   'pa': 'passive-aggressive',
                   'passive-aggressive': 'passive-aggressive',
                   'arow': 'arow'}


### PR DESCRIPTION
Hi, 

I haven't tried it, but `averaged_perceptron` should fail because crfsuite checks for `averaged-perceptron`.
